### PR TITLE
Refine research highlight layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,6 +82,10 @@
     .image-block {
       margin: 4em 0;
       text-align: center;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 1.5em;
     }
 
     .image-block h2 {
@@ -97,10 +101,14 @@
     }
 
     .image-block img {
-      max-width: 100%;
+      max-width: min(100%, 720px);
+      width: 100%;
       height: auto;
       border-radius: 12px;
       box-shadow: 0 6px 16px rgba(0,0,0,0.1);
+      display: block;
+      margin-left: auto;
+      margin-right: auto;
     }
 
     .manifesto {


### PR DESCRIPTION
## Summary
- convert the research highlight section into a flex column so its content stays centered within the page
- constrain the highlight image width and auto-center it for consistent presentation

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68d5b2ca2b68832e835d73e3dc424c08